### PR TITLE
園の検索結果一覧をキャッシュ

### DIFF
--- a/store/center/actions.js
+++ b/store/center/actions.js
@@ -25,7 +25,10 @@ export default {
     }
   },
 
-  async search({ commit }) {
+  async search({ commit , state}) {
+
+    if(state.itemsIsCached) return;
+
     commit("SEARCH_CENTER");
 
     try {

--- a/store/center/actions.js
+++ b/store/center/actions.js
@@ -26,8 +26,9 @@ export default {
   },
 
   async search({ commit, getters }) {
-
-    if(getters['items'].length !=0 ) return;
+    if (getters['items'].length > 0) {
+      return;
+    }
 
     commit("SEARCH_CENTER");
 
@@ -141,7 +142,7 @@ export default {
     //保育施設(開園時間と終園時間)
     let selectedOpeningTime = filters.startTime;
     if(selectedOpeningTime != null ) selectedOpeningTime = selectedOpeningTime.replace(/:/g, "");
-    
+
     let selectedClosingTime = filters.endTime;
     if(selectedClosingTime != null) selectedClosingTime = selectedClosingTime.replace(/:/g, "");
 
@@ -211,11 +212,11 @@ export default {
         let serviceFlag = false;
 
         serviceProperties.forEach(p => {
-          if (filters.services[p.key] == true && 
+          if (filters.services[p.key] == true &&
             (row.nursery.service[p.key] == null || row.nursery.service[p.key] == true)) {
               serviceFlag = true;
           }
-        });  
+        });
 
         return serviceFlag ? row: false;
 

--- a/store/center/actions.js
+++ b/store/center/actions.js
@@ -25,9 +25,9 @@ export default {
     }
   },
 
-  async search({ commit , state}) {
+  async search({ commit, getters }) {
 
-    if(state.itemsIsCached) return;
+    if(getters['items'].length !=0 ) return;
 
     commit("SEARCH_CENTER");
 

--- a/store/center/index.js
+++ b/store/center/index.js
@@ -7,5 +7,6 @@ export const state = () => ({
     ownerships: []
   },
   error: undefined,
-  loading: false
+  loading: false,
+  itemsIsCached: false
 });

--- a/store/center/index.js
+++ b/store/center/index.js
@@ -8,5 +8,4 @@ export const state = () => ({
   },
   error: undefined,
   loading: false,
-  itemsIsCached: false
 });

--- a/store/center/mutations.js
+++ b/store/center/mutations.js
@@ -60,7 +60,6 @@ export default {
   SEARCH_CENTER_SUCCESS(state, data) {
     state.items = _.map(data.search.items, item => extendProps(item));
     state.loading = false;
-    state.itemsIsCached = true;
   },
 
   SEARCH_CENTER_FAILURE(state, error) {

--- a/store/center/mutations.js
+++ b/store/center/mutations.js
@@ -60,6 +60,7 @@ export default {
   SEARCH_CENTER_SUCCESS(state, data) {
     state.items = _.map(data.search.items, item => extendProps(item));
     state.loading = false;
+    state.itemsIsCached = true;
   },
 
   SEARCH_CENTER_FAILURE(state, error) {


### PR DESCRIPTION
isCashedで検索状態を取得し、未検索の場合のみAPI呼び出しするよう修正。
これで地図、お気に入り、履歴への遷移は早くなったはず。