### PR TITLE
お気に入りの裏側で発生しているエラーの修正

### DIFF
--- a/pages/favorites/index.vue
+++ b/pages/favorites/index.vue
@@ -3,7 +3,7 @@
     <template v-if="hasFavorite">
       <v-list three-line>
         <template v-for="(item, index) in favorites">
-          <v-divider v-if="index > 0" :key="item.id" />
+          <v-divider v-if="index > 0" :key="index" />
           <v-list-item :key="item.id" @click="open(item)">
             <v-list-item-content>
               <v-list-item-title>{{ item.name }}</v-list-item-title>


### PR DESCRIPTION
お気に入りが 2件以上あるときに裏側でキーの重複エラーがでていたので修正。