### PR TITLE
ルートチェンジのタイミングで、保育施設情報を再取得しない

### DIFF
--- a/store/center/actions.js
+++ b/store/center/actions.js
@@ -28,7 +28,11 @@ export default {
     }
   },
 
-  async search({ commit }) {
+  async search({ commit , getters }) {
+    if(getters.items.length > 0 ) {
+      return;
+    }
+      
     commit("SEARCH_CENTER");
 
     try {


### PR DESCRIPTION
遅延描画の対応の祭にこちらの対応が外れていたようなので再度追加