### PR TITLE
Intersection Observer API を利用するための Polyfill を導入

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6363,6 +6363,11 @@
         "through": "^2.3.6"
       }
     },
+    "intersection-observer": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/intersection-observer/-/intersection-observer-0.7.0.tgz",
+      "integrity": "sha512-Id0Fij0HsB/vKWGeBe9PxeY45ttRiBmhFyyt/geBdDHBYNctMRTE3dC1U3ujzz3lap+hVXlEcVaB56kZP/eEUg=="
+    },
     "invariant": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@typeform/embed": "0.15.1",
     "aws-appsync": "3.0.2",
     "graphql-tag": "2.10.1",
+    "intersection-observer": "0.7.0",
     "lodash": "4.17.15",
     "luxon": "1.21.3",
     "mapbox-gl": "1.6.1",


### PR DESCRIPTION
v-lazy を使うにあたって、IE11 で必要っぽいので導入します。

https://vuetifyjs.com/ja/components/lazy