### PR TITLE
Renovate の設定ファイルを削除

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,0 @@
-{
-  "extends": [
-    "config:base"
-  ]
-}


### PR DESCRIPTION
これまで Renovate を使っていましたが、Dependabot が Github の機能として統合されたので、こっちを使います。
そのため、Renovate の設定ファイルは不要になるので、削除します。