### PR TITLE
aws-appsyncとgraphql-tagの最新化

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1849,9 +1849,9 @@
       }
     },
     "@redux-offline/redux-offline": {
-      "version": "2.5.2-native.0",
-      "resolved": "https://registry.npmjs.org/@redux-offline/redux-offline/-/redux-offline-2.5.2-native.0.tgz",
-      "integrity": "sha512-ZRH1E0oz9VAnfBZJsyH8O2D3tjQOd0Yz/piPmRsbE1wuoUb+eVM9SZNQetIdJvqmiNs1n3VDfcEeADEbT2dhyg==",
+      "version": "2.5.2-native.3",
+      "resolved": "https://registry.npmjs.org/@redux-offline/redux-offline/-/redux-offline-2.5.2-native.3.tgz",
+      "integrity": "sha512-xo1M4wFJDJjANn9w6faru0/8rerd28vQpbNTbEe7DX57RyRqSGsDilb0temH/kAg3GheQTlO59ipRum2bcmXvw==",
       "requires": {
         "@babel/runtime": "^7.5.5",
         "redux-persist": "^4.6.0"
@@ -2460,20 +2460,20 @@
       }
     },
     "apollo-link": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.2.3.tgz",
-      "integrity": "sha512-iL9yS2OfxYhigme5bpTbmRyC+Htt6tyo2fRMHT3K1XRL/C5IQDDz37OjpPy4ndx7WInSvfSZaaOTKFja9VWqSw==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.2.5.tgz",
+      "integrity": "sha512-GJHEE4B06oEB58mpRRwW6ISyvgX2aCqCLjpcE3M/6/4e+ZVeX7fRGpMJJDq2zZ8n7qWdrEuY315JfxzpsJmUhA==",
       "requires": {
         "apollo-utilities": "^1.0.0",
-        "zen-observable-ts": "^0.8.10"
+        "zen-observable-ts": "^0.8.12"
       }
     },
     "apollo-link-context": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/apollo-link-context/-/apollo-link-context-1.0.9.tgz",
-      "integrity": "sha512-gcC1WH7mTyNtS0bF4fPijepXqnERwZjm1JCkuOT6ADBTpDTXIqK+Ec+/QkVawDO26EV9OX5ujWe4kI1qC6T6tA==",
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/apollo-link-context/-/apollo-link-context-1.0.11.tgz",
+      "integrity": "sha512-aEM7zp3O1V4jVIm7me60T7Sw7vCuuGzE9ppE0ttGiud8slUbh7dTAgxirTEg3PjdPQA5ZoLCwqnGb+DzTxu+1g==",
       "requires": {
-        "apollo-link": "^1.2.3"
+        "apollo-link": "^1.2.5"
       }
     },
     "apollo-link-dedup": {
@@ -2499,11 +2499,12 @@
       }
     },
     "apollo-link-http": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/apollo-link-http/-/apollo-link-http-1.3.1.tgz",
-      "integrity": "sha512-41L2NA49h8FGaKlQSnQbSrMkO0XHfxGD4fqkLve12OWmqCJaoGb/5Qn+OFiAZm/E8e/MiMJ+6+4Agutw6REu2g==",
+      "version": "1.5.8",
+      "resolved": "https://registry.npmjs.org/apollo-link-http/-/apollo-link-http-1.5.8.tgz",
+      "integrity": "sha512-wkmj9fL5B4QYjw7q7w0GyetfqQKnA0QXGoh+/UK+LXJ+jLEz6JP2eLxrwgpX7o4ID6Og7l1JfeVxJE5fV1j2bg==",
       "requires": {
-        "apollo-link": "^1.0.6"
+        "apollo-link": "^1.2.5",
+        "apollo-link-http-common": "^0.2.7"
       }
     },
     "apollo-link-http-common": {
@@ -2530,12 +2531,12 @@
       }
     },
     "apollo-link-retry": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/apollo-link-retry/-/apollo-link-retry-2.2.5.tgz",
-      "integrity": "sha512-DZUyTVDBH5toiqtgJxM955wnXVXeRDRkXrFOEUvXsXyEJ0Bb9ej5YfrdJBPyQL2vB6yP/1l8nEFR1ivV88ivgw==",
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/apollo-link-retry/-/apollo-link-retry-2.2.7.tgz",
+      "integrity": "sha512-HlpeA09PZ6RL/l/nIYmJ+DjsdQ315HLLiSTLUo/Zq56wDuzlmbbEKUPkK5Sb92nFCwZOgm+TvHCrS6zUF33eQw==",
       "requires": {
         "@types/zen-observable": "0.8.0",
-        "apollo-link": "^1.2.3"
+        "apollo-link": "^1.2.5"
       },
       "dependencies": {
         "@types/zen-observable": {
@@ -2745,19 +2746,19 @@
       }
     },
     "aws-appsync": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/aws-appsync/-/aws-appsync-3.0.2.tgz",
-      "integrity": "sha512-gGifzZ8EcEnxdyo4n+d0BTsTL8m0MWaV9xT3YUv+ni1czt3Hgw2gpD+LUEvVhF1w2F2Af7nlrR1LQHMZFb4dIQ==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/aws-appsync/-/aws-appsync-4.0.1.tgz",
+      "integrity": "sha512-rgYMKrV0VWd4Tm8+DIhnDLZE7vUWFHCStEb7WrIELpQBOwFF6IVJtUWwcJoMgbi+ajp6r/5ou9s4PBA81SpYlg==",
       "requires": {
-        "@redux-offline/redux-offline": "2.5.2-native.0",
+        "@redux-offline/redux-offline": "2.5.2-native.3",
         "apollo-cache-inmemory": "1.3.12",
         "apollo-client": "2.4.6",
-        "apollo-link": "1.2.3",
-        "apollo-link-context": "1.0.9",
-        "apollo-link-http": "1.3.1",
-        "apollo-link-retry": "2.2.5",
-        "aws-appsync-auth-link": "^2.0.1",
-        "aws-appsync-subscription-link": "^2.0.1",
+        "apollo-link": "1.2.5",
+        "apollo-link-context": "1.0.11",
+        "apollo-link-http": "1.5.8",
+        "apollo-link-retry": "2.2.7",
+        "aws-appsync-auth-link": "^2.0.3",
+        "aws-appsync-subscription-link": "^2.2.1",
         "aws-sdk": "2.518.0",
         "debug": "2.6.9",
         "graphql": "0.13.0",
@@ -2793,15 +2794,6 @@
         "debug": "2.6.9"
       },
       "dependencies": {
-        "apollo-link": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.2.5.tgz",
-          "integrity": "sha512-GJHEE4B06oEB58mpRRwW6ISyvgX2aCqCLjpcE3M/6/4e+ZVeX7fRGpMJJDq2zZ8n7qWdrEuY315JfxzpsJmUhA==",
-          "requires": {
-            "apollo-utilities": "^1.0.0",
-            "zen-observable-ts": "^0.8.12"
-          }
-        },
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -2831,46 +2823,6 @@
         "url": "^0.11.0"
       },
       "dependencies": {
-        "@types/zen-observable": {
-          "version": "0.8.0",
-          "resolved": "https://registry.npmjs.org/@types/zen-observable/-/zen-observable-0.8.0.tgz",
-          "integrity": "sha512-te5lMAWii1uEJ4FwLjzdlbw3+n0FZNOvFXHxQDKeT0dilh7HOzdMzV2TrJVUzq8ep7J4Na8OUYPRLSQkJHAlrg=="
-        },
-        "apollo-link": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.2.5.tgz",
-          "integrity": "sha512-GJHEE4B06oEB58mpRRwW6ISyvgX2aCqCLjpcE3M/6/4e+ZVeX7fRGpMJJDq2zZ8n7qWdrEuY315JfxzpsJmUhA==",
-          "requires": {
-            "apollo-utilities": "^1.0.0",
-            "zen-observable-ts": "^0.8.12"
-          }
-        },
-        "apollo-link-context": {
-          "version": "1.0.11",
-          "resolved": "https://registry.npmjs.org/apollo-link-context/-/apollo-link-context-1.0.11.tgz",
-          "integrity": "sha512-aEM7zp3O1V4jVIm7me60T7Sw7vCuuGzE9ppE0ttGiud8slUbh7dTAgxirTEg3PjdPQA5ZoLCwqnGb+DzTxu+1g==",
-          "requires": {
-            "apollo-link": "^1.2.5"
-          }
-        },
-        "apollo-link-http": {
-          "version": "1.5.8",
-          "resolved": "https://registry.npmjs.org/apollo-link-http/-/apollo-link-http-1.5.8.tgz",
-          "integrity": "sha512-wkmj9fL5B4QYjw7q7w0GyetfqQKnA0QXGoh+/UK+LXJ+jLEz6JP2eLxrwgpX7o4ID6Og7l1JfeVxJE5fV1j2bg==",
-          "requires": {
-            "apollo-link": "^1.2.5",
-            "apollo-link-http-common": "^0.2.7"
-          }
-        },
-        "apollo-link-retry": {
-          "version": "2.2.7",
-          "resolved": "https://registry.npmjs.org/apollo-link-retry/-/apollo-link-retry-2.2.7.tgz",
-          "integrity": "sha512-HlpeA09PZ6RL/l/nIYmJ+DjsdQ315HLLiSTLUo/Zq56wDuzlmbbEKUPkK5Sb92nFCwZOgm+TvHCrS6zUF33eQw==",
-          "requires": {
-            "@types/zen-observable": "0.8.0",
-            "apollo-link": "^1.2.5"
-          }
-        },
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -6034,9 +5986,9 @@
       }
     },
     "graphql-tag": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.10.1.tgz",
-      "integrity": "sha512-jApXqWBzNXQ8jYa/HLkZJaVw9jgwNqZkywa2zfFn16Iv1Zb7ELNHkJaXHR7Quvd5SIGsy6Ny7SUKATgnu05uEg=="
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.11.0.tgz",
+      "integrity": "sha512-VmsD5pJqWJnQZMUeRwrDhfgoyqcfwEkvtpANqcoUG8/tOLkwNgU9mzub/Mc78OJMhHjx7gfAMTxzdG43VGg3bA=="
     },
     "grid-index": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
   "dependencies": {
     "@nuxtjs/google-tag-manager": "2.3.2",
     "@typeform/embed": "0.25.0",
-    "aws-appsync": "3.0.2",
-    "graphql-tag": "2.10.1",
+    "aws-appsync": "4.0.1",
+    "graphql-tag": "2.11.0",
     "lodash": "4.17.20",
     "luxon": "1.25.0",
     "mapbox-gl": "1.12.0",


### PR DESCRIPTION
以下のライブラリを更新し一通り動作確認した
・"aws-appsync": "4.0.1"
・"graphql-tag": "2.11.0"
