### PR TITLE
詳細画面で備考欄が複数見えるの対応

### DIFF
--- a/components/nurseries/Detail.vue
+++ b/components/nurseries/Detail.vue
@@ -34,12 +34,6 @@
         <v-list-item-title>{{ item.nursery.facility.numberOfParkingLot }}台</v-list-item-title>
       </v-list-item-content>
     </v-list-item>
-    <v-list-item>
-      <v-list-item-content>
-        <v-list-item-subtitle>備考</v-list-item-subtitle>
-        <v-list-item-title>{{ remarks }}</v-list-item-title>
-      </v-list-item-content>
-    </v-list-item>
   </v-list>
 </template>
 
@@ -79,16 +73,6 @@ export default {
       // すべてのitemsが×でなければ空きあり
       const is_available = !availabilities.every(item => item === "×");
       return is_available ? "あり" : "なし";
-    },
-
-    remarks() {
-      if (this.item.nursery) {
-        return this.item.nursery.facility.remarks
-      } else if (this.item.afterSchool) {
-        return this.item.afterSchool.facility.remarks
-      } else {
-        return null
-      }
     }
   },
 

--- a/components/nurseries/Service.vue
+++ b/components/nurseries/Service.vue
@@ -47,12 +47,6 @@
         </v-list-item-content>
       </v-list-item>
     </template>
-    <v-list-item>
-      <v-list-item-content>
-        <v-list-item-subtitle>備考</v-list-item-subtitle>
-        <v-list-item-title>{{ remarks }}</v-list-item-title>
-      </v-list-item-content>
-    </v-list-item>
   </v-list>
 </template>
 
@@ -72,18 +66,6 @@ export default {
     item: {
       type: Object,
       required: true
-    }
-  },
-
-  computed: {
-    remarks() {
-      if (this.item.nursery) {
-        return this.item.nursery.service.remarks
-      } else if (this.item.afterSchool) {
-        return this.item.afterSchool.service.remarks
-      } else {
-        return null
-      }
     }
   }
 }

--- a/components/nurseries/Summary.vue
+++ b/components/nurseries/Summary.vue
@@ -50,6 +50,8 @@
       <v-list-item-content>
         <v-list-item-subtitle>備考</v-list-item-subtitle>
         <v-list-item-title>{{ remarks }}</v-list-item-title>
+        <v-list-item-title>{{ facilityRemarks }}</v-list-item-title>
+        <v-list-item-title>{{ serviceRemarks }}</v-list-item-title>
       </v-list-item-content>
     </v-list-item>
   </v-list>
@@ -89,17 +91,28 @@ export default {
     },
     
     remarks() {
+      const remarks = this.item.remarks;
+      return remarks;
+    },
+
+    facilityRemarks() {
       let remarks;
       if (this.item.nursery) {
-        remarks = this.item.remarks + 
-                  this.item.nursery.facility.remarks + 
-                  this.item.nursery.service.remarks;
+        remarks = this.item.nursery.facility.remarks
       } else if (this.item.afterSchool) {
-        remarks = this.item.remarks + 
-                  this.item.afterSchool.facility.remarks + 
-                  this.item.afterSchool.service.remarks;
+        remarks = this.item.afterSchool.facility.remarks
       }
-      return remarks ? remarks:"なし";
+      return remarks;
+    },
+
+    serviceRemarks() {
+      let remarks;
+      if (this.item.nursery) {
+        remarks = this.item.nursery.service.remarks;
+      } else if (this.item.afterSchool) {
+        remarks = this.item.afterSchool.service.remarks;
+      }
+      return remarks;
     }
   },
 

--- a/components/nurseries/Summary.vue
+++ b/components/nurseries/Summary.vue
@@ -50,9 +50,15 @@
       <v-list-item-content>
         <v-list-item-subtitle>備考</v-list-item-subtitle>
         <v-list-item-title>
-          <p>{{ remarks }}</p>
-          <p>{{ facilityRemarks }}</p>
-          <p>{{ serviceRemarks }}</p>
+          <p v-if="item.nursery">
+            {{ remarks }}
+          </p>
+          <p v-if="item.nursery">
+            {{ facilityRemarks }}
+          </p>
+          <p v-if="item.nursery">
+            {{ serviceRemarks }}
+          </p>
         </v-list-item-title>
       </v-list-item-content>
     </v-list-item>

--- a/components/nurseries/Summary.vue
+++ b/components/nurseries/Summary.vue
@@ -50,13 +50,13 @@
       <v-list-item-content>
         <v-list-item-subtitle>備考</v-list-item-subtitle>
         <v-list-item-title>
-          <p v-if="item.nursery">
+          <p v-if="remarks">
             {{ remarks }}
           </p>
-          <p v-if="item.nursery">
+          <p v-if="facilityRemarks">
             {{ facilityRemarks }}
           </p>
-          <p v-if="item.nursery">
+          <p v-if="serviceRemarks">
             {{ serviceRemarks }}
           </p>
         </v-list-item-title>

--- a/components/nurseries/Summary.vue
+++ b/components/nurseries/Summary.vue
@@ -46,11 +46,11 @@
         <v-list-item-title>{{ targetAge }}</v-list-item-title>
       </v-list-item-content>
     </v-list-item>
-    <v-list-item v-if="item.remarks">
-      <v-flex xs6 sm3>
-        <v-list-item-title>施設基本情報備考</v-list-item-title>
-      </v-flex>
-      <v-list-item-content>{{ item.remarks }}</v-list-item-content>
+    <v-list-item>
+      <v-list-item-content>
+        <v-list-item-subtitle>備考</v-list-item-subtitle>
+        <v-list-item-title>{{ remarks }}</v-list-item-title>
+      </v-list-item-content>
     </v-list-item>
   </v-list>
 </template>
@@ -87,6 +87,20 @@ export default {
     targetAge() {
       return `${this.item.nursery.facility.ageFrom} 〜 ${this.item.nursery.facility.ageTo}歳`;
     },
+    
+    remarks() {
+      let remarks;
+      if (this.item.nursery) {
+        remarks = this.item.remarks + 
+                  this.item.nursery.facility.remarks + 
+                  this.item.nursery.service.remarks;
+      } else if (this.item.afterSchool) {
+        remarks = this.item.remarks + 
+                  this.item.afterSchool.facility.remarks + 
+                  this.item.afterSchool.service.remarks;
+      }
+      return remarks ? remarks:"なし";
+    }
   },
 
   methods: {

--- a/components/nurseries/Summary.vue
+++ b/components/nurseries/Summary.vue
@@ -49,9 +49,11 @@
     <v-list-item>
       <v-list-item-content>
         <v-list-item-subtitle>備考</v-list-item-subtitle>
-        <v-list-item-title>{{ remarks }}</v-list-item-title>
-        <v-list-item-title>{{ facilityRemarks }}</v-list-item-title>
-        <v-list-item-title>{{ serviceRemarks }}</v-list-item-title>
+        <v-list-item-title>
+          <p>{{ remarks }}</p>
+          <p>{{ facilityRemarks }}</p>
+          <p>{{ serviceRemarks }}</p>
+        </v-list-item-title>
       </v-list-item-content>
     </v-list-item>
   </v-list>
@@ -91,8 +93,7 @@ export default {
     },
     
     remarks() {
-      const remarks = this.item.remarks;
-      return remarks;
+      return this.item.remarks;
     },
 
     facilityRemarks() {


### PR DESCRIPTION
**Trello**
https://trello.com/c/qrAvXs5h/139-

**修正内容**
次の3つの備考欄の内容を1か所に統合
・施設基本情報備考
・保育施設属性備考/学童施設属性備考
・保育サービス備考/学童サービス備考

レイアウトとして施設基本情報のあった地図の上に表示

**スクリーンショット**
![image](https://user-images.githubusercontent.com/3695706/94370273-02abcd80-012a-11eb-8054-508f25d6fd96.png)
