### PR TITLE
こどもルーム -> 子どもルーム

### DIFF
--- a/data/centerTypes.js
+++ b/data/centerTypes.js
@@ -11,7 +11,7 @@ const centerTypes = {
     { id: "NI", name: "認可外保育園", value: "認可外保育所" }
   ],
   afterSchool: [
-    { id: "AA", name: "こどもルーム", value: "こどもルーム" }
+    { id: "AA", name: "子どもルーム", value: "子どもルーム" }
   ]
 }
 

--- a/store/center/mutations.js
+++ b/store/center/mutations.js
@@ -39,7 +39,7 @@ function generateType(item) {
     const type = _.find(centerTypes.nursery, { value: item.nursery.facility.nurseryType })
     return type.name
   } else {
-    return 'こどもルーム'
+    return _.first(centerTypes.afterSchool).name
   }
 }
 


### PR DESCRIPTION
千葉市における正式名称は「子どもルーム」なので、こちらで統一する

https://trello.com/c/S4qQmcH1
