### PR TITLE
詳細画面からの遷移先URLの修正

### DIFF
--- a/components/nurseries/Summary.vue
+++ b/components/nurseries/Summary.vue
@@ -34,9 +34,9 @@
       <v-list-item-content>
         <v-list-item-subtitle>ウェブサイト</v-list-item-subtitle>
         <v-list-item-title>
-          <router-link :to="item.website" target="_blank">
+          <a :href="item.website" target="_blank">
             {{ item.website }}
-          </router-link>
+          </a>
         </v-list-item-title>
       </v-list-item-content>
     </v-list-item>


### PR DESCRIPTION
外部サイトのURLをrouter-linkで囲んでいたため正しく表示されていなかった。