### PR TITLE
マップの詳細画面 施設名改行対応

### DIFF
--- a/pages/maps/index.vue
+++ b/pages/maps/index.vue
@@ -338,4 +338,8 @@ export default {
   bottom: 0;
   width: 100%;
 }
+
+.v-toolbar__title {
+  white-space: normal;
+}
 </style>


### PR DESCRIPTION
マップの詳細画面 施設名改行対応

### Trello
[マップの詳細画面で、名前が切れる場合がある](https://trello.com/c/AInupz7f/148-%E3%83%9E%E3%83%83%E3%83%97%E3%81%AE%E8%A9%B3%E7%B4%B0%E7%94%BB%E9%9D%A2%E3%81%A7%E3%80%81%E5%90%8D%E5%89%8D%E3%81%8C%E5%88%87%E3%82%8C%E3%82%8B%E5%A0%B4%E5%90%88%E3%81%8C%E3%81%82%E3%82%8B)

### 対応
Vtoolbar.scssで`white-space: no-wrap;`になっていたので、
pages/maps/index.vueのstyle scopedで`white-space: normal;`を指定しました。
### 対応後
<img width="362" alt="スクリーンショット 2020-10-10 10 50 52" src="https://user-images.githubusercontent.com/11253385/95643158-52a27100-0ae8-11eb-8c08-6aca68250a17.png">


